### PR TITLE
Changes upstream() to look beyond the scope of one parent

### DIFF
--- a/wdl/binding.py
+++ b/wdl/binding.py
@@ -247,7 +247,7 @@ class Scatter(Scope):
             up_val = None
             while parent and not up_val:
                 fqn = '{}.{}'.format(parent.name, lhs_expr)
-                up_val = hierarchy[-1].resolve(fqn)
+                up_val = root.resolve(fqn)
                 parent = parent.parent
             if up_val:
                 up.add(up_val)

--- a/wdl/binding.py
+++ b/wdl/binding.py
@@ -194,8 +194,15 @@ class Call(Scope):
                 up.update(scope.upstream())
         for expression in self.inputs.values():
             for node in wdl.find_asts(expression.ast, "MemberAccess"):
-                fqn = '{}.{}'.format(self.parent.name, expr_str(node.attr('lhs')))
-                up.add(hierarchy[-1].resolve(fqn))
+                lhs_expr = expr_str(node.attr('lhs'))
+                parent = self.parent
+                up_val = None
+                while parent and not up_val:
+                    fqn = '{}.{}'.format(parent.name, lhs_expr)
+                    up_val = hierarchy[-1].resolve(fqn)
+                    parent = parent.parent
+                if up_val:
+                    up.add(up_val)
         return up
     def downstream(self):
         root = scope_hierarchy(self)[-1]
@@ -235,8 +242,15 @@ class Scatter(Scope):
         root = scope_hierarchy(self)[-1]
         up = set()
         for node in wdl.find_asts(self.collection.ast, "MemberAccess"):
-            fqn = '{}.{}'.format(self.parent.name, expr_str(node.attr('lhs')))
-            up.add(self.parent.resolve(fqn))
+            lhs_expr = expr_str(node.attr('lhs'))
+            parent = self.parent
+            up_val = None
+            while parent and not up_val:
+                fqn = '{}.{}'.format(parent.name, lhs_expr)
+                up_val = hierarchy[-1].resolve(fqn)
+                parent = parent.parent
+            if up_val:
+                up.add(up_val)
         return up
 
 class WorkflowOutputs(list):

--- a/wdl/test/test_binding.py
+++ b/wdl/test/test_binding.py
@@ -257,3 +257,48 @@ workflow w {
     assert call_t2.downstream() == set([call_t3, scatter])
     assert call_t3.downstream() == set()
     assert scatter.downstream() == set([call_t3])
+
+def test_beyond_scatter_upstream_downstream():
+    wdl_namespace = wdl.loads("""
+task t1 {
+  File i
+  String pattern
+  command { grep '${pattern}' ${i} > "filtered" }
+  output { File filtered = "filtered" }
+}
+
+task t2 {
+  File i
+  Array[String] s = ["a", "b", "c"]
+  command {
+    cat ${i} > out_file
+    echo -e "${sep="\\n" s}" >> out_file
+  }
+  output { Array[String] strings = read_lines("out_file") }
+}
+
+task t3 {
+  String x
+  command {echo ${x}}
+  output { String y = read_string(stdout()) }
+}
+
+workflow w {
+  call t1
+  call t2 {
+    input: i=t1.filtered
+  }
+  Array[String] s = ["a", "b", "c"]
+  scatter(n in s) {
+    call t3 {
+      input: x=t2.strings
+    }
+  }
+}
+""")
+
+    call_t1 = wdl_namespace.resolve('w.t1')
+    call_t2 = wdl_namespace.resolve('w.t2')
+    call_t3 = wdl_namespace.resolve('w.t3')
+    scatter = call_t3.parent
+    assert call_t3.upstream() == set([call_t2, scatter])


### PR DESCRIPTION
This should let a call within a scatter block that has input from a call above that scatter block, see that call as an upstream node. 
